### PR TITLE
删除无用的addresses变量

### DIFF
--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -134,7 +134,7 @@ class ProductController extends Controller
             (new ScoreLogServe)->visitedProductAddScore($user, $product);
         }
 
-        return view('products.show', compact('product', 'addresses', 'recommendProducts'));
+        return view('products.show', compact('product', 'recommendProducts'));
     }
 
     /**


### PR DESCRIPTION
控制器中包含未声明的addresses变量，而且在视图中并未使用，会引发找不到变量的错误。
```
compact(): Undefined variable: addresses
```